### PR TITLE
fixing typo in surprise emotion, making emotions public

### DIFF
--- a/src/main/java/cognitivej/vision/emotion/Emotion.java
+++ b/src/main/java/cognitivej/vision/emotion/Emotion.java
@@ -225,7 +225,7 @@ public class Emotion {
     }
 
     public class Scores {
-        double anger, contempt, disgust, fear, happiness, neutral, sadness, surprise;
+        public double anger, contempt, disgust, fear, happiness, neutral, sadness, surprise;
 
         public Map<EmotionScore, Double> scores() {
             return new HashMap<EmotionScore, Double>() {{
@@ -236,7 +236,7 @@ public class Emotion {
                 put(EmotionScore.HAPPINESS, happiness);
                 put(EmotionScore.NEUTRAL, neutral);
                 put(EmotionScore.SADNESS, sadness);
-                put(EmotionScore.SUPRISE, surprise);
+                put(EmotionScore.SURPRISE, surprise);
             }};
 
         }
@@ -249,7 +249,7 @@ public class Emotion {
     }
 
     public enum EmotionScore {
-        ANGER, CONTEMPT, DISGUST, FEAR, HAPPINESS, NEUTRAL, SADNESS, SUPRISE;
+        ANGER, CONTEMPT, DISGUST, FEAR, HAPPINESS, NEUTRAL, SADNESS, SURPRISE;
     }
 
 


### PR DESCRIPTION
Was using this and noticed a typo in SUPRISE. Also, made the emotions public for easier access. could also make private with setters and getters but since it is a small class, this seemed easier.